### PR TITLE
get some math rendering

### DIFF
--- a/content/post/post/change-of-basis.md
+++ b/content/post/post/change-of-basis.md
@@ -1,6 +1,7 @@
 +++
 date = "2016-09-20T21:53:36+02:00"
 title = "Change of basis in a vector space"
+hasMath = true
 +++
 
 A fascinating characteristic of the human mind is the ability to make connections between different objects and phenomena. What allows us to do this is a common ground along which things can be understood, connected and thus compared.
@@ -12,7 +13,8 @@ To represent different points in space we need some sort of unit of measurement 
 Now imagine a flat world, a two-dimensional universe or plane that’s defined along x and y axes. The conventional way of representing points in 2D space is to use the standard coordinate system, defined by the basis vectors \(i\) and \(j\). Notice, that it is just a choice we have collectively made. We could also represent points in 2D using some alternative units of measurement (i.e. along some different set of gridlines).
 Given our choice, we can now think of a vector as a scaled version of our basis vectors \(i\) and \(j\):
 
-\[
+```
+$$
   v=\begin{pmatrix}
   3\\
   2
@@ -21,17 +23,18 @@ Given our choice, we can now think of a vector as a scaled version of our basis 
   1 & 0 \\
   0 & 1
  \end{pmatrix}
-\]
+$$
+```
 
-As in our standard system we always refer to \(i\) and \(j\) as our basis, we can ignore them and just use the following notation:
-<div>$$
-\[
+As in our standard system we always refer to `\(i\)` and `\(j\)` as our basis, we can ignore them and just use the following notation:
+```
+$$
   v=\begin{pmatrix}
   3\\
   2
  \end{pmatrix}
-\]
-$$</div>
+$$
+```
 
 **Some thoughts on linear transformation**
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,7 +4,7 @@
     <script type="text/javascript">
       $(".heading").fitText();
     </script>
-    {{ if .GetParam "hasMath"}}
-        <script>renderMathInElement(document.body);</script>
+    {{ if .Params.hasmath }}
+        <script>renderMathInElement(document.body, {ignoredTags: []});</script>
     {{ end }}
     </footer>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,4 +7,10 @@
         <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:300|Montserrat:700' rel='stylesheet' type='text/css'>
         <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
         <script src="//code.jquery.com/jquery-1.10.2.min.js"></script>
+
+        {{ if .Params.hasmath }}
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.css">
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
+        {{ end }}
     </head>


### PR DESCRIPTION
Here is one way to get math rendering.
- It seems like that Hugo MathJax page claiming that putting stuff inside a `<div>` stops it from being escaped was pretty much lying 😭 But putting stuff inside backquotes forces it to be left alone.
- Also you had placed the katex code in `header.html`, but it seems like only `head.html` is actually being used.
- Also `.GetParam` doesn't seem to be a thing, at least in my version of Hugo.

The remaining issue is that there is now a gray background behind the display-style math blocks, since they are in a `<pre>` block due to the triple backquotes, so… you'll need to do some css magic to get rid of that for `pre > span.katex-display` or something like that, I hate css.

This whole thing makes Hugo's markdown parser look really pathetic though, kramdown (the one jekyll uses) has built-in support for math blocks 😭 

Go to "Files changed" above to see what I changed to get it working.

Hope this helps!
